### PR TITLE
Deprecation note.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: Use github.com/unravelin/null/v4
 module github.com/unravelin/null
 
 go 1.17


### PR DESCRIPTION
We're not really on v2, but prior to adding a go.mod, Go recorded our version as 2.1.2+incompatible.