### PR TITLE
Add support for "underlying" types in the signatures

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -24,36 +24,32 @@ type Bool struct {
 	sql.NullBool
 }
 
-func True() Bool {
-	return B(true)
-}
+func True() Bool { return B(true) }
 
-func False() Bool {
-	return B(false)
-}
+func False() Bool { return B(false) }
 
 // NewBool creates a new Bool
-func NewBool(b bool, valid bool) Bool {
+func NewBool[T ~bool](b T, valid bool) Bool {
 	return Bool{
 		NullBool: sql.NullBool{
-			Bool:  b,
+			Bool:  bool(b),
 			Valid: valid,
 		},
 	}
 }
 
 // B creates a new Bool that will always be valid.
-func B(b bool) Bool {
+func B[T ~bool](b T) Bool {
 	return BoolFrom(b)
 }
 
 // BoolFrom creates a new Bool that will always be valid.
-func BoolFrom(b bool) Bool {
+func BoolFrom[T ~bool](b T) Bool {
 	return NewBool(b, true)
 }
 
 // BoolFromPtr creates a new Bool that will be null if f is nil.
-func BoolFromPtr(b *bool) Bool {
+func BoolFromPtr[T ~bool](b *T) Bool {
 	if b == nil {
 		return NewBool(false, false)
 	}

--- a/bool_test.go
+++ b/bool_test.go
@@ -11,7 +11,6 @@ import (
 
 var (
 	boolJSON     = []byte(`true`)
-	falseJSON    = []byte(`false`)
 	nullBoolJSON = []byte(`{"Bool":true,"Valid":true}`)
 )
 

--- a/bool_test.go
+++ b/bool_test.go
@@ -30,7 +30,8 @@ func TestBoolFromPtr(t *testing.T) {
 	b := BoolFromPtr(bptr)
 	assertBool(t, b, "BoolFromPtr()")
 
-	null := BoolFromPtr(nil)
+	bptr = nil
+	null := BoolFromPtr(bptr)
 	assertNullBool(t, null, "BoolFromPtr(nil)")
 }
 
@@ -215,6 +216,19 @@ func TestBoolEqual(t *testing.T) {
 	b1 = NewBool(true, true)
 	b2 = NewBool(false, true)
 	assertBoolEqualIsFalse(t, b1, b2)
+}
+
+func TestUnderlyingBool(t *testing.T) {
+	type foo bool
+	const val bool = true
+	f := foo(val)
+	nullF := B(f)
+	if !nullF.Valid {
+		t.Fatalf("expected the null.Bool to be valid")
+	}
+	if act := nullF.Bool; val != act {
+		t.Fatalf("expected %v, but given %v", val, act)
+	}
 }
 
 func assertBool(t *testing.T, b Bool, from string) {

--- a/float.go
+++ b/float.go
@@ -22,29 +22,29 @@ type Float struct {
 }
 
 // NewFloat creates a new Float
-func NewFloat(f float64, valid bool) Float {
+func NewFloat[T ~float64](f T, valid bool) Float {
 	return Float{
 		NullFloat64: sql.NullFloat64{
-			Float64: f,
+			Float64: float64(f),
 			Valid:   valid,
 		},
 	}
 }
 
 // F creates a new Float that will always be valid.
-func F(f float64) Float {
+func F[T ~float64](f T) Float {
 	return FloatFrom(f)
 }
 
 // FloatFrom creates a new Float that will always be valid.
-func FloatFrom(f float64) Float {
+func FloatFrom[T ~float64](f T) Float {
 	return NewFloat(f, true)
 }
 
 // FloatFromPtr creates a new Float that be null if f is nil.
-func FloatFromPtr(f *float64) Float {
+func FloatFromPtr[T ~float64](f *T) Float {
 	if f == nil {
-		return NewFloat(0, false)
+		return NewFloat(float64(0), false)
 	}
 	return NewFloat(*f, true)
 }

--- a/float_test.go
+++ b/float_test.go
@@ -15,7 +15,6 @@ import (
 var (
 	floatJSON           = []byte(`1.2345`)
 	floatJSONString     = []byte(`"1.2345"`)
-	floatBlankJSON      = []byte(`""`)
 	nullFloatJSON       = []byte(`{"Float64":1.2345,"Valid":true}`)
 	nullFloatJSONString = []byte(`{"Float64":"1.2345","Valid":true}`)
 )
@@ -56,7 +55,7 @@ func TestUnmarshalFloat(t *testing.T) {
 			exp: FloatFrom(1.2345),
 		},
 		{
-			in: []byte(` "1.2345"  	 `),
+			in:  []byte(` "1.2345"  	 `),
 			exp: FloatFrom(1.2345),
 		},
 		{

--- a/float_test.go
+++ b/float_test.go
@@ -23,9 +23,9 @@ func TestFloatFrom(t *testing.T) {
 	f := FloatFrom(1.2345)
 	assertFloat(t, f, "FloatFrom()")
 
-	zero := FloatFrom(0)
+	zero := FloatFrom(0.0)
 	if !zero.Valid {
-		t.Error("FloatFrom(0)", "is invalid, but should be valid")
+		t.Error("FloatFrom(0.0)", "is invalid, but should be valid")
 	}
 }
 
@@ -35,8 +35,22 @@ func TestFloatFromPtr(t *testing.T) {
 	f := FloatFromPtr(iptr)
 	assertFloat(t, f, "FloatFromPtr()")
 
-	null := FloatFromPtr(nil)
+	iptr = nil
+	null := FloatFromPtr(iptr)
 	assertNullFloat(t, null, "FloatFromPtr(nil)")
+}
+
+func TestUnderlyingFloat(t *testing.T) {
+	type foo float64
+	const val float64 = 0.5772156649
+	f := foo(val)
+	nullF := F(f)
+	if !nullF.Valid {
+		t.Fatalf("expected the null.Float to be valid")
+	}
+	if act := nullF.Float64; val != act {
+		t.Fatalf("expected %f, but given %f", val, act)
+	}
 }
 
 func TestUnmarshalFloat(t *testing.T) {
@@ -196,7 +210,7 @@ func TestMarshalFloat(t *testing.T) {
 	assertJSONEquals(t, data, "1.2345", "non-empty json marshal")
 
 	// invalid values should be encoded as null
-	null := NewFloat(0, false)
+	null := NewFloat(0.0, false)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, "null", "null json marshal")
@@ -209,7 +223,7 @@ func TestMarshalFloatText(t *testing.T) {
 	assertJSONEquals(t, data, "1.2345", "non-empty text marshal")
 
 	// invalid values should be encoded as null
-	null := NewFloat(0, false)
+	null := NewFloat(0.0, false)
 	data, err = null.MarshalText()
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "null text marshal")
@@ -222,7 +236,7 @@ func TestFloatPointer(t *testing.T) {
 		t.Errorf("bad %s float: %#v ≠ %v\n", "pointer", ptr, 1.2345)
 	}
 
-	null := NewFloat(0, false)
+	null := NewFloat(0.0, false)
 	ptr = null.Ptr()
 	if ptr != nil {
 		t.Errorf("bad %s float: %#v ≠ %s\n", "nil pointer", ptr, "nil")
@@ -235,19 +249,19 @@ func TestFloatIsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := NewFloat(0, false)
+	null := NewFloat(0.0, false)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
 
-	zero := NewFloat(0, true)
+	zero := NewFloat(0.0, true)
 	if zero.IsZero() {
 		t.Errorf("IsZero() should be false")
 	}
 }
 
 func TestFloatSetValid(t *testing.T) {
-	change := NewFloat(0, false)
+	change := NewFloat(0.0, false)
 	assertNullFloat(t, change, "SetValid()")
 	change.SetValid(1.2345)
 	assertFloat(t, change, "SetValid()")
@@ -297,28 +311,28 @@ func TestFloatValueOrZero(t *testing.T) {
 }
 
 func TestFloatEqual(t *testing.T) {
-	f1 := NewFloat(10, false)
-	f2 := NewFloat(10, false)
+	f1 := NewFloat(10.0, false)
+	f2 := NewFloat(10.0, false)
 	assertFloatEqualIsTrue(t, f1, f2)
 
-	f1 = NewFloat(10, false)
-	f2 = NewFloat(20, false)
+	f1 = NewFloat(10.0, false)
+	f2 = NewFloat(20.0, false)
 	assertFloatEqualIsTrue(t, f1, f2)
 
-	f1 = NewFloat(10, true)
-	f2 = NewFloat(10, true)
+	f1 = NewFloat(10.0, true)
+	f2 = NewFloat(10.0, true)
 	assertFloatEqualIsTrue(t, f1, f2)
 
-	f1 = NewFloat(10, true)
-	f2 = NewFloat(10, false)
+	f1 = NewFloat(10.0, true)
+	f2 = NewFloat(10.0, false)
 	assertFloatEqualIsFalse(t, f1, f2)
 
-	f1 = NewFloat(10, false)
-	f2 = NewFloat(10, true)
+	f1 = NewFloat(10.0, false)
+	f2 = NewFloat(10.0, true)
 	assertFloatEqualIsFalse(t, f1, f2)
 
-	f1 = NewFloat(10, true)
-	f2 = NewFloat(20, true)
+	f1 = NewFloat(10.0, true)
+	f2 = NewFloat(20.0, true)
 	assertFloatEqualIsFalse(t, f1, f2)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/unravelin/null/v4
 
-go 1.17
+go 1.18
 
 require (
 	github.com/google/go-cmp v0.5.6

--- a/int.go
+++ b/int.go
@@ -20,27 +20,27 @@ type Int struct {
 }
 
 // NewInt creates a new Int
-func NewInt(i int64, valid bool) Int {
+func NewInt[T ~int64 | ~int](i T, valid bool) Int {
 	return Int{
 		NullInt64: sql.NullInt64{
-			Int64: i,
+			Int64: int64(i),
 			Valid: valid,
 		},
 	}
 }
 
 // I creates a new Int that will always be valid.
-func I(i int64) Int {
+func I[T ~int64 | ~int](i T) Int {
 	return IntFrom(i)
 }
 
 // IntFrom creates a new Int that will always be valid.
-func IntFrom(i int64) Int {
+func IntFrom[T ~int64 | ~int](i T) Int {
 	return NewInt(i, true)
 }
 
 // IntFromPtr creates a new Int that be null if i is nil.
-func IntFromPtr(i *int64) Int {
+func IntFromPtr[T ~int64 | ~int](i *T) Int {
 	if i == nil {
 		return NewInt(0, false)
 	}

--- a/int_test.go
+++ b/int_test.go
@@ -35,8 +35,22 @@ func TestIntFromPtr(t *testing.T) {
 	i := IntFromPtr(iptr)
 	assertInt(t, i, "IntFromPtr()")
 
-	null := IntFromPtr(nil)
+	iptr = nil
+	null := IntFromPtr(iptr)
 	assertNullInt(t, null, "IntFromPtr(nil)")
+}
+
+func TestUnderlyingInt(t *testing.T) {
+	type foo int
+	const val int64 = 1711
+	f := foo(val)
+	nullF := I(f)
+	if !nullF.Valid {
+		t.Fatalf("expected the null.Int to be valid")
+	}
+	if act := nullF.Int64; val != act {
+		t.Fatalf("expected %d, but given %d", val, act)
+	}
 }
 
 func TestIntUnmarshal(t *testing.T) {
@@ -55,7 +69,7 @@ func TestIntUnmarshal(t *testing.T) {
 			exp: IntFrom(12345),
 		},
 		{
-			in: []byte(` "12345"  	 `),
+			in:  []byte(` "12345"  	 `),
 			exp: IntFrom(12345),
 		},
 		{

--- a/string.go
+++ b/string.go
@@ -20,23 +20,33 @@ type String struct {
 	sql.NullString
 }
 
+// NewString creates a new String
+func NewString[T ~string](s T, valid bool) String {
+	return String{
+		NullString: sql.NullString{
+			String: string(s),
+			Valid:  valid,
+		},
+	}
+}
+
 // S creates a new String that will never be blank.
-func S(s string) String {
+func S[T ~string](s T) String {
 	return StringFrom(s)
 }
 
 // ZS creates a new String that is valid if s is not zero.
-func ZS(s string) String {
+func ZS[T ~string](s T) String {
 	return NewString(s, s != "")
 }
 
 // StringFrom creates a new String that will never be blank.
-func StringFrom(s string) String {
+func StringFrom[T ~string](s T) String {
 	return NewString(s, true)
 }
 
 // StringFromPtr creates a new String that be null if s is nil.
-func StringFromPtr(s *string) String {
+func StringFromPtr[T ~string](s *T) String {
 	if s == nil {
 		return NewString("", false)
 	}
@@ -49,16 +59,6 @@ func (s String) ValueOrZero() string {
 		return ""
 	}
 	return s.String
-}
-
-// NewString creates a new String
-func NewString(s string, valid bool) String {
-	return String{
-		NullString: sql.NullString{
-			String: s,
-			Valid:  valid,
-		},
-	}
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/string_test.go
+++ b/string_test.go
@@ -3,7 +3,7 @@ package null
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/mailru/easyjson"
@@ -280,7 +280,7 @@ func BenchmarkMarshalNullString(b *testing.B) {
 	b.ReportAllocs()
 	b.RunParallel(func(b *testing.PB) {
 		var ns String
-		enc := json.NewEncoder(ioutil.Discard)
+		enc := json.NewEncoder(io.Discard)
 		for b.Next() {
 			enc.Encode(&ns)
 		}

--- a/string_test.go
+++ b/string_test.go
@@ -19,10 +19,6 @@ var (
 	invalidJSON = []byte(`:)`)
 )
 
-type stringInStruct struct {
-	Test String `json:"test,omitempty"`
-}
-
 func TestStringFrom(t *testing.T) {
 	str := StringFrom("test")
 	assertStr(t, str, "StringFrom() string")
@@ -159,14 +155,6 @@ func TestMarshalString(t *testing.T) {
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "string marshal text")
 }
-
-// Tests omitempty... broken until Go 1.4
-// func TestMarshalStringInStruct(t *testing.T) {
-// 	obj := stringInStruct{Test: StringFrom("")}
-// 	data, err := json.Marshal(obj)
-// 	maybePanic(err)
-// 	assertJSONEquals(t, data, `{}`, "null string in struct")
-// }
 
 func TestStringPointer(t *testing.T) {
 	str := StringFrom("test")

--- a/string_test.go
+++ b/string_test.go
@@ -35,7 +35,8 @@ func TestStringFromPtr(t *testing.T) {
 	str := StringFromPtr(sptr)
 	assertStr(t, str, "StringFromPtr() string")
 
-	null := StringFromPtr(nil)
+	sptr = nil
+	null := StringFromPtr(sptr)
 	assertNullStr(t, null, "StringFromPtr(nil)")
 }
 
@@ -147,7 +148,8 @@ func TestMarshalString(t *testing.T) {
 	maybePanic(err)
 	assertJSONEquals(t, data, "", "string marshal text")
 
-	null := StringFromPtr(nil)
+	var sptr *string
+	null := StringFromPtr(sptr)
 	data, err = json.Marshal(null)
 	maybePanic(err)
 	assertJSONEquals(t, data, `null`, "null json marshal")
@@ -186,7 +188,8 @@ func TestStringIsZero(t *testing.T) {
 		t.Errorf("IsZero() should be false")
 	}
 
-	null := StringFromPtr(nil)
+	var sptr *string
+	null := StringFromPtr(sptr)
 	if !null.IsZero() {
 		t.Errorf("IsZero() should be true")
 	}
@@ -247,6 +250,19 @@ func TestStringEqual(t *testing.T) {
 	str1 = NewString("foo", true)
 	str2 = NewString("bar", true)
 	assertStringEqualIsFalse(t, str1, str2)
+}
+
+func TestUnderlyingString(t *testing.T) {
+	type foo string
+	const val string = "foo!"
+	f := foo(val)
+	nullF := S(f)
+	if !nullF.Valid {
+		t.Fatalf("expected the null.String to be valid")
+	}
+	if act := nullF.String; val != act {
+		t.Fatalf("expected %s, but given %s", val, act)
+	}
 }
 
 func maybePanic(err error) {

--- a/zero/string_test.go
+++ b/zero/string_test.go
@@ -15,10 +15,6 @@ var (
 	invalidJSON = []byte(`:)`)
 )
 
-type stringInStruct struct {
-	Test String `json:"test,omitempty"`
-}
-
 func TestStringFrom(t *testing.T) {
 	str := StringFrom("test")
 	assertStr(t, str, "StringFrom() string")
@@ -89,14 +85,6 @@ func TestMarshalString(t *testing.T) {
 	maybePanic(err)
 	assertJSONEquals(t, data, `""`, "empty json marshal")
 }
-
-// Tests omitempty... broken until Go 1.4
-// func TestMarshalStringInStruct(t *testing.T) {
-// 	obj := stringInStruct{Test: StringFrom("")}
-// 	data, err := json.Marshal(obj)
-// 	maybePanic(err)
-// 	assertJSONEquals(t, data, `{}`, "null string in struct")
-// }
 
 func TestStringPointer(t *testing.T) {
 	str := StringFrom("test")

--- a/zero/time_test.go
+++ b/zero/time_test.go
@@ -179,6 +179,9 @@ func TestTimeValue(t *testing.T) {
 	ti := TimeFrom(timeValue1)
 	v, err := ti.Value()
 	maybePanic(err)
+	if v != timeValue1 {
+		t.Errorf("bad time.Time value: %v ≠ %v", v, timeValue1)
+	}
 	if ti.Time != timeValue1 {
 		t.Errorf("bad time.Time value: %v ≠ %v", ti.Time, timeValue1)
 	}


### PR DESCRIPTION
> [!CAUTION]
> This is a BREAKING CHANGE in three respects.
>
> 1. The minimum version of Go has been lifted from 1.17 to 1.18. This is required to support generics.
> 2. "Naked" nils as arguments are no longer accepted as values; they must now be explicitly typed.
> 3. Integral forms will not be implicitly converted to floats. That is, expressions such as `F(0)` are now invalid, but `F(0.0)` is valid.
>
> I'm not sure what the appropriate language is for point 2, but the upshot is that (e.g.) `F(nil)` is now invalid.

This branch has three commits. The first removes or uses unused variables and commented-out tests. (The tests do not pass when reinstated, contra the comment about Go 1.4.) The second removes io/ioutil, as this is a deprecated package. The third makes the breaking change.

The intent with this change is to make it possible for people to declare custom types such as

```go
type foo string
```

and then later freely call

```go
f := foo("bar")
null.S(f)
```

without explicitly casting `f` to its underlying type.