### PR TITLE
Avoid panic when unmarshalling empty data

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -70,6 +70,11 @@ func (b *Bool) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
+	if len(data) == 0 {
+		b.Valid = false
+		return nil
+	}
+
 	if data[0] == '{' {
 		if err := json.Unmarshal(data, &b.NullBool); err != nil {
 			return fmt.Errorf("null: couldn't unmarshal JSON: %w", err)

--- a/bool.go
+++ b/bool.go
@@ -65,12 +65,7 @@ func (b Bool) ValueOrZero() bool {
 // It supports number and null input.
 // 0 will not be considered a null Bool.
 func (b *Bool) UnmarshalJSON(data []byte) error {
-	if bytes.Equal(data, nullLiteral) {
-		b.Valid = false
-		return nil
-	}
-
-	if len(data) == 0 {
+	if bytes.Equal(data, nullLiteral) || len(data) == 0 {
 		b.Valid = false
 		return nil
 	}

--- a/bool_test.go
+++ b/bool_test.go
@@ -50,6 +50,12 @@ func TestUnmarshalBool(t *testing.T) {
 	maybePanic(err)
 	assertNullBool(t, null, "null json")
 
+	var empty Bool
+	var data []byte
+	err = empty.UnmarshalJSON(data)
+	maybePanic(err)
+	assertNullBool(t, empty, "null json")
+
 	var badType Bool
 	err = json.Unmarshal(intJSON, &badType)
 	if err == nil {

--- a/float.go
+++ b/float.go
@@ -61,39 +61,39 @@ func (f Float) ValueOrZero() float64 {
 // It supports number and null input.
 // 0 will not be considered a null Float.
 // It also supports unmarshalling a sql.NullFloat64.
-func (i *Float) UnmarshalJSON(data []byte) error {
+func (f *Float) UnmarshalJSON(data []byte) error {
 	if bytes.Equal(data, nullLiteral) {
-		i.Valid = false
+		f.Valid = false
 		return nil
 	}
 
 	if len(data) == 0 {
-		i.Valid = false
+		f.Valid = false
 		return nil
 	}
 
 	if data[0] == '{' {
 		// Try the struct form of Float.
 		type basicFloat Float
-		var ii basicFloat
-		if json.Unmarshal(data, &ii) == nil {
-			*i = Float(ii)
+		var bf basicFloat
+		if json.Unmarshal(data, &bf) == nil {
+			*f = Float(bf)
 			return nil
 		}
 
 		// Try the struct form of Float, but with a string Float64.
-		var si struct {
+		var sf struct {
 			Float64 string
 			Valid   bool
 		}
-		if err := json.Unmarshal(data, &si); err != nil {
+		if err := json.Unmarshal(data, &sf); err != nil {
 			return err
 		}
-		i.Valid = si.Valid
-		if si.Valid {
+		f.Valid = sf.Valid
+		if sf.Valid {
 			var err error
-			i.Float64, err = strconv.ParseFloat(si.Float64, 64)
-			i.Valid = (err == nil)
+			f.Float64, err = strconv.ParseFloat(sf.Float64, 64)
+			f.Valid = (err == nil)
 		}
 		return nil
 	}
@@ -104,16 +104,16 @@ func (i *Float) UnmarshalJSON(data []byte) error {
 	}
 
 	var err error
-	i.Float64, err = strconv.ParseFloat(*(*string)(unsafe.Pointer(&data)), 64)
-	i.Valid = (err == nil)
+	f.Float64, err = strconv.ParseFloat(*(*string)(unsafe.Pointer(&data)), 64)
+	f.Valid = (err == nil)
 	return err
 }
 
 // UnmarshalEasyJSON is an easy-JSON specific decoder, that should be more efficient than the standard one.
-func (i *Float) UnmarshalEasyJSON(w *jlexer.Lexer) {
+func (f *Float) UnmarshalEasyJSON(w *jlexer.Lexer) {
 	if w.IsNull() {
 		w.Skip()
-		i.Valid = false
+		f.Valid = false
 		return
 	}
 	if w.IsDelim('{') {
@@ -133,20 +133,20 @@ func (i *Float) UnmarshalEasyJSON(w *jlexer.Lexer) {
 				if data[0] == '"' {
 					data = data[1 : len(data)-1]
 				}
-				f, err := strconv.ParseFloat(*(*string)(unsafe.Pointer(&data)), 64)
+				fVal, err := strconv.ParseFloat(*(*string)(unsafe.Pointer(&data)), 64)
 				if err != nil {
 					w.AddError(&jlexer.LexerError{
 						Reason: err.Error(),
 						Data:   string(data),
 					})
-					i.Float64 = 0
-					i.Valid = false
+					f.Float64 = 0
+					f.Valid = false
 					return
 				}
-				i.Float64 = f
-				i.Valid = true
+				f.Float64 = fVal
+				f.Valid = true
 			case "valid", "Valid":
-				i.Valid = w.Bool()
+				f.Valid = w.Bool()
 			}
 			w.WantComma()
 		}
@@ -158,18 +158,18 @@ func (i *Float) UnmarshalEasyJSON(w *jlexer.Lexer) {
 	if data[0] == '"' {
 		data = data[1 : len(data)-1]
 	}
-	f, err := strconv.ParseFloat(*(*string)(unsafe.Pointer(&data)), 64)
+	fVal, err := strconv.ParseFloat(*(*string)(unsafe.Pointer(&data)), 64)
 	if err != nil {
 		w.AddError(&jlexer.LexerError{
 			Reason: err.Error(),
 			Data:   string(data),
 		})
-		i.Float64 = 0
-		i.Valid = false
+		f.Float64 = 0
+		f.Valid = false
 		return
 	}
-	i.Float64 = f
-	i.Valid = true
+	f.Float64 = fVal
+	f.Valid = true
 }
 
 // UnmarshalText implements encoding.TextUnmarshaler.

--- a/float.go
+++ b/float.go
@@ -130,6 +130,10 @@ func (f *Float) UnmarshalEasyJSON(w *jlexer.Lexer) {
 			case "float64", "Float64":
 				// Read float from raw.
 				data := w.Raw()
+				if len(data) == 0 {
+					f.Valid = false
+					return
+				}
 				if data[0] == '"' {
 					data = data[1 : len(data)-1]
 				}
@@ -155,6 +159,10 @@ func (f *Float) UnmarshalEasyJSON(w *jlexer.Lexer) {
 
 	// Read float from raw.
 	data := w.Raw()
+	if len(data) == 0 {
+		f.Valid = false
+		return
+	}
 	if data[0] == '"' {
 		data = data[1 : len(data)-1]
 	}

--- a/float.go
+++ b/float.go
@@ -62,12 +62,7 @@ func (f Float) ValueOrZero() float64 {
 // 0 will not be considered a null Float.
 // It also supports unmarshalling a sql.NullFloat64.
 func (f *Float) UnmarshalJSON(data []byte) error {
-	if bytes.Equal(data, nullLiteral) {
-		f.Valid = false
-		return nil
-	}
-
-	if len(data) == 0 {
+	if bytes.Equal(data, nullLiteral) || len(data) == 0 {
 		f.Valid = false
 		return nil
 	}

--- a/float.go
+++ b/float.go
@@ -67,6 +67,11 @@ func (i *Float) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
+	if len(data) == 0 {
+		i.Valid = false
+		return nil
+	}
+
 	if data[0] == '{' {
 		// Try the struct form of Float.
 		type basicFloat Float

--- a/float_test.go
+++ b/float_test.go
@@ -2,6 +2,7 @@ package null
 
 import (
 	"encoding/json"
+	"io"
 	"math"
 	"reflect"
 	"strconv"
@@ -79,6 +80,11 @@ func TestUnmarshalFloat(t *testing.T) {
 		{
 			in:  nullFloatJSONString,
 			exp: FloatFrom(1.2345),
+		},
+		{
+			in:             []byte{},
+			expErrType:     reflect.TypeOf((*json.SyntaxError)(nil)),
+			expErrTypeEasy: reflect.TypeOf(io.EOF),
 		},
 		{
 			in: nullJSON,

--- a/int.go
+++ b/int.go
@@ -59,12 +59,7 @@ func (i Int) ValueOrZero() int64 {
 // It supports number, string, and null input.
 // 0 will not be considered a null Int.
 func (i *Int) UnmarshalJSON(data []byte) error {
-	if bytes.Equal(data, nullLiteral) {
-		i.Valid = false
-		return nil
-	}
-
-	if len(data) == 0 {
+	if bytes.Equal(data, nullLiteral) || len(data) == 0 {
 		i.Valid = false
 		return nil
 	}

--- a/int.go
+++ b/int.go
@@ -64,6 +64,11 @@ func (i *Int) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
+	if len(data) == 0 {
+		i.Valid = false
+		return nil
+	}
+
 	if data[0] == '{' {
 		// Try the struct form of Int.
 		type basicInt Int

--- a/int_test.go
+++ b/int_test.go
@@ -2,6 +2,7 @@ package null
 
 import (
 	"encoding/json"
+	"io"
 	"math"
 	"reflect"
 	"strconv"
@@ -79,6 +80,11 @@ func TestIntUnmarshal(t *testing.T) {
 		{
 			in:  nullIntJSONString,
 			exp: IntFrom(12345),
+		},
+		{
+			in:             []byte{},
+			expErrType:     reflect.TypeOf((*json.SyntaxError)(nil)),
+			expErrTypeEasy: reflect.TypeOf(io.EOF),
 		},
 		{
 			in: nullJSON,

--- a/string.go
+++ b/string.go
@@ -64,12 +64,7 @@ func (s String) ValueOrZero() string {
 // UnmarshalJSON implements json.Unmarshaler.
 // It supports string and null input. Blank string input does not produce a null String.
 func (s *String) UnmarshalJSON(data []byte) error {
-	if bytes.Equal(data, nullLiteral) {
-		s.Valid = false
-		return nil
-	}
-
-	if len(data) == 0 {
+	if bytes.Equal(data, nullLiteral) || len(data) == 0 {
 		s.Valid = false
 		return nil
 	}

--- a/string.go
+++ b/string.go
@@ -69,6 +69,11 @@ func (s *String) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
+	if len(data) == 0 {
+		s.Valid = false
+		return nil
+	}
+
 	if data[0] == '{' {
 		if err := json.Unmarshal(data, &s.NullString); err != nil {
 			return fmt.Errorf("null: couldn't unmarshal JSON: %w", err)

--- a/string_test.go
+++ b/string_test.go
@@ -58,6 +58,10 @@ func TestUnmarshalString(t *testing.T) {
 		t.Error("blank string should be valid")
 	}
 
+	var empty String
+	maybePanic(empty.UnmarshalJSON([]byte{}))
+	assertNullStr(t, empty, "null json")
+
 	var null String
 	err = json.Unmarshal(nullJSON, &null)
 	maybePanic(err)


### PR DESCRIPTION
When the `UnmarshalJSON` method is called it can panic if the given data has no bytes, handle this case by setting `Valid` to false. 

In addition, rename same variables and receivers for `Float` methods from `i` to `f`.